### PR TITLE
Prevent multiple key activation by one user

### DIFF
--- a/addons/sourcemod/scripting/Keys_Core.sp
+++ b/addons/sourcemod/scripting/Keys_Core.sp
@@ -327,6 +327,7 @@ public OnClientDisconnect(iClient)
 {
 	g_iAttempts[iClient] = 0;
 	g_bIsBlocked[iClient] = false;
+	g_bIsProcessing[iClient] = false;
 }
 
 public OnClientPostAdminCheck(iClient)

--- a/addons/sourcemod/scripting/Keys_Core.sp
+++ b/addons/sourcemod/scripting/Keys_Core.sp
@@ -57,6 +57,7 @@ public OnPluginStart()
 
 	RegAdminCmds();
 
+	g_hKeysInProcessing = CreateArray(ByteCountToCells(KEYS_MAX_LENGTH));
 	Connect_DB();
 }
 
@@ -327,7 +328,6 @@ public OnClientDisconnect(iClient)
 {
 	g_iAttempts[iClient] = 0;
 	g_bIsBlocked[iClient] = false;
-	g_bIsProcessing[iClient] = false;
 }
 
 public OnClientPostAdminCheck(iClient)

--- a/addons/sourcemod/scripting/keys/vars.sp
+++ b/addons/sourcemod/scripting/keys/vars.sp
@@ -28,3 +28,4 @@ new String:g_CVAR_sKeyTemplate[64];
 new g_CVAR_iAttempts;
 new g_CVAR_iBlockTime;
 
+new bool:g_bIsProcessing[MAXPLAYERS+1];

--- a/addons/sourcemod/scripting/keys/vars.sp
+++ b/addons/sourcemod/scripting/keys/vars.sp
@@ -28,4 +28,4 @@ new String:g_CVAR_sKeyTemplate[64];
 new g_CVAR_iAttempts;
 new g_CVAR_iBlockTime;
 
-new bool:g_bIsProcessing[MAXPLAYERS+1];
+new Handle:g_hKeysInProcessing;

--- a/addons/sourcemod/translations/keys_core.phrases.txt
+++ b/addons/sourcemod/translations/keys_core.phrases.txt
@@ -253,6 +253,12 @@
 		"fi"	"Olet antanut väärän avaimen! Yrityksiä jäljellä: {1}"
 	}
 
+	"ERROR_PROCESSING"
+	{
+		"en"	"Your previous key in processing. Try again."
+		"ru"	"Ваш прошлый ключ ещё в обработке. Попробуйте позже."
+	}
+
 	"FOREVER"
 	{
 		"ru"	"Навсегда"


### PR DESCRIPTION
Thanks @BlackYuzia for report and testing.

Issue description: one user can activate one key multiple time when query to select key is processing.
For example, `key KEY;key KEY` can activate key `KEY` two times:
![image](https://user-images.githubusercontent.com/12576822/64908001-40021080-d70b-11e9-902b-bf71380cbd29.png)